### PR TITLE
chore: change target framework to dotnet standard 2.0

### DIFF
--- a/FailableResult.Tests/FailableResult.Tests.csproj
+++ b/FailableResult.Tests/FailableResult.Tests.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FailableResult/FailableResult.csproj
+++ b/FailableResult/FailableResult.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <AssemblyVersion>4.1.0.0</AssemblyVersion>
-    <Version>4.1.0</Version>
+    <AssemblyVersion>5.0.0.0</AssemblyVersion>
+    <Version>5.0.0</Version>
     <Authors>Milan Gatyas &lt;12131213@seznam.cz&gt;</Authors>
     <Company></Company>
     <Product />


### PR DESCRIPTION
netcoreapp2.1 is out of support and it's not usable by newer versions of dotnet. 

According to [Microsoft documentation](https://docs.microsoft.com/en-us/dotnet/standard/net-standard?tabs=net-standard-2-0) .NET Standard should be supported by future versions of dotnet.
